### PR TITLE
chore(lint): enable import/no-default-export for the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "react-app/jest"
     ],
     "rules": {
+      "import/no-default-export": "on",
       "react/react-in-jsx-scope": "off"
     }
   },


### PR DESCRIPTION
enables "import/no-default-export" to discourage using default exports